### PR TITLE
Fix argument passing of nick in use reply

### DIFF
--- a/irc/client.d
+++ b/irc/client.d
@@ -853,7 +853,7 @@ class IrcClient
 					throw new IrcErrorException(this, `"433 Nick already in use" was unhandled`, cause);
 				}
 
-				auto failedNick = line.arguments[0];
+				auto failedNick = line.arguments[1];
 				bool handled = false;
 
 				foreach(cb; onNickInUse)


### PR DESCRIPTION
The nick in use message actually has `*` as its first argument, and the nick as its second.