### PR TITLE
Use negotiated SSL method rather than hardcoded SSLv3

### DIFF
--- a/source/ssl/openssl.d
+++ b/source/ssl/openssl.d
@@ -28,7 +28,7 @@ extern(C)
 	char* function(c_ulong e, char* buf) ERR_error_string_p;
 
 	SSL_CTX* function(const(SSL_METHOD)* meth) SSL_CTX_new_p;
-	const(SSL_METHOD)* function() SSLv3_client_method_p; /* SSLv3 */
+	const(SSL_METHOD)* function() SSLv23_client_method_p; /* negotiated */
 
 	SSL* function(SSL_CTX* ctx) SSL_new_p;
 	int function(SSL* s, int fd) SSL_set_fd_p;
@@ -78,7 +78,7 @@ void loadOpenSSL()
 	ssl.resolve!SSL_get_error_p;
 
 	ssl.resolve!SSL_CTX_new_p;
-	ssl.resolve!SSLv3_client_method_p;
+	ssl.resolve!SSLv23_client_method_p;
 
 	ssl.resolve!SSL_new_p;
 	ssl.resolve!SSL_set_fd_p;

--- a/source/ssl/socket.d
+++ b/source/ssl/socket.d
@@ -15,7 +15,7 @@ private SSL_CTX* sslContext;
 void initSslContext()
 {
 	if(!sslContext)
-		sslContext = SSL_CTX_new_p(SSLv3_client_method_p());
+		sslContext = SSL_CTX_new_p(SSLv23_client_method_p());
 }
 
 version(force_ssl_load) static this()


### PR DESCRIPTION
Finally figured out why my bot couldn't connect over SSL after the IRC server we were using was rebuilt. It didn't support SSLv3 which was the hardcoded protocol method in Dirk. This switches it to negotiate the protocol.

`TLS_client_method` would be better but that's not even available in the libssl that comes with Ubuntu 16.04. SSLv2 could be blocked with `SSL_CTX_set_options` but since certificate verification isn't even on I don't think it's a big deal.